### PR TITLE
Translates: title, header and breadcrumbs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Translate CMS Pages in Magento.
 
 Use: In any CMS Page or Block use {{translate text="Text here"}} and the text will be translatable with the Inline translator.
 
+Besides the inline translator the module will also translate title in head and header block as well as enable translation for page breadcrumbs.
+
 Source: http://www.magentocommerce.com/boards/viewthread/179598/#
 
 If you want this to be a part of Magento2, add a +1 <a href="https://github.com/magento/magento2/pull/875" target="_blank">here</a>.

--- a/app/code/local/MB/Translate/Block/Core/Template.php
+++ b/app/code/local/MB/Translate/Block/Core/Template.php
@@ -9,6 +9,6 @@ class MB_Translate_Block_Core_Template extends Mage_Core_Block_Template
 
     public function getContentHeading()
     {
-        return $this->__(parent::getContentHeading());
+        return Mage::helper('mb_translate')->getTranslateModule()->__(parent::getContentHeading());
     }
 }

--- a/app/code/local/MB/Translate/Block/Core/Template.php
+++ b/app/code/local/MB/Translate/Block/Core/Template.php
@@ -1,0 +1,14 @@
+<?php
+
+class MB_Translate_Block_Core_Template extends Mage_Core_Block_Template
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function getContentHeading()
+    {
+        return $this->__(parent::getContentHeading());
+    }
+}

--- a/app/code/local/MB/Translate/Block/Page/Html/Breadcrumbs.php
+++ b/app/code/local/MB/Translate/Block/Page/Html/Breadcrumbs.php
@@ -1,0 +1,18 @@
+<?php
+
+class MB_Translate_Block_Page_Html_Breadcrumbs extends Mage_Page_Block_Html_Breadcrumbs
+{
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function addCrumb($crumbName, $crumbInfo, $after = false)
+    {
+        // This solution might try to translate some values twice since
+        // everything that comes in will be translated.
+        if (isset($crumbInfo['label'])) $crumbInfo['label'] = $this->__($crumbInfo['label']);
+        if (isset($crumbInfo['title'])) $crumbInfo['title'] = $this->__($crumbInfo['title']);
+        return parent::addCrumb($crumbName, $crumbInfo, $after);
+    }
+}

--- a/app/code/local/MB/Translate/Block/Page/Html/Breadcrumbs.php
+++ b/app/code/local/MB/Translate/Block/Page/Html/Breadcrumbs.php
@@ -9,10 +9,9 @@ class MB_Translate_Block_Page_Html_Breadcrumbs extends Mage_Page_Block_Html_Brea
 
     public function addCrumb($crumbName, $crumbInfo, $after = false)
     {
-        // This solution might try to translate some values twice since
-        // everything that comes in will be translated.
-        if (isset($crumbInfo['label'])) $crumbInfo['label'] = $this->__($crumbInfo['label']);
-        if (isset($crumbInfo['title'])) $crumbInfo['title'] = $this->__($crumbInfo['title']);
+        $module = Mage::helper('mb_translate')->getTranslateModule();
+        if (isset($crumbInfo['label'])) $crumbInfo['label'] = $module->__($crumbInfo['label']);
+        if (isset($crumbInfo['title'])) $crumbInfo['title'] = $module->__($crumbInfo['title']);
         return parent::addCrumb($crumbName, $crumbInfo, $after);
     }
 }

--- a/app/code/local/MB/Translate/Block/Page/Html/Head.php
+++ b/app/code/local/MB/Translate/Block/Page/Html/Head.php
@@ -18,21 +18,21 @@ class MB_Translate_Block_Page_Html_Head extends Mage_Page_Block_Html_Head
     public function getTitle()
     {
         $title = parent::getTitle();
-        if ($this->shouldTranslate) return $this->__($title);
+        if ($this->shouldTranslate) return Mage::helper('mb_translate')->getTranslateModule()->__($title);
         return $title;
     }
 
     public function getDescription()
     {
         $description = parent::getDescription();
-        if ($this->shouldTranslate) return $this->__($description);
+        if ($this->shouldTranslate) return Mage::helper('mb_translate')->getTranslateModule()->__($description);
         return $description;
     }
 
     public function getKeywords()
     {
         $keywords = parent::getKeywords();
-        if ($this->shouldTranslate) return $this->__($keywords);
+        if ($this->shouldTranslate) return Mage::helper('mb_translate')->getTranslateModule()->__($keywords);
         return $keywords;
     }
 }

--- a/app/code/local/MB/Translate/Block/Page/Html/Head.php
+++ b/app/code/local/MB/Translate/Block/Page/Html/Head.php
@@ -1,0 +1,38 @@
+<?php
+
+class MB_Translate_Block_Page_Html_Head extends Mage_Page_Block_Html_Head
+{
+    protected $shouldTranslate;
+
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    public function setTranslate(bool $shouldTranslate = true)
+    {
+        $this->shouldTranslate = $shouldTranslate;
+        return $this;
+    }
+
+    public function getTitle()
+    {
+        $title = parent::getTitle();
+        if ($this->shouldTranslate) return $this->__($title);
+        return $title;
+    }
+
+    public function getDescription()
+    {
+        $description = parent::getDescription();
+        if ($this->shouldTranslate) return $this->__($description);
+        return $description;
+    }
+
+    public function getKeywords()
+    {
+        $keywords = parent::getKeywords();
+        if ($this->shouldTranslate) return $this->__($keywords);
+        return $keywords;
+    }
+}

--- a/app/code/local/MB/Translate/Helper/Data.php
+++ b/app/code/local/MB/Translate/Helper/Data.php
@@ -2,5 +2,56 @@
 
 class MB_Translate_Helper_Data extends Mage_Core_Helper_Abstract
 {
+    const XML_DEFAULT_MODULE_PATH = 'cms/translate/default_module';
+    const DEFAULT_MODULE          = 'page';
+    protected $_defaultModule     = null;
 
+    public function getTranslateModule($module = null)
+    {
+        return Mage::helper($this->getTranslateModuleName($module));
+    }
+
+    public function getTranslateModuleName($module = null)
+    {
+        if (empty($module)) return $this->_getDefaultModule();
+        return $this->_getTranslateModuleName($module);
+    }
+
+    protected function _getTranslateModuleName($module)
+    {
+        try
+        {
+            $helper = Mage::helper($module);
+            return $module;
+        }
+        catch (Exception $e)
+        {
+            return $this->_getDefaultModule();
+        }
+    }
+
+    protected function _getDefaultModule()
+    {
+        if (is_null($this->_defaultModule))
+        {
+            $moduleName = Mage::getStoreConfig(self::XML_DEFAULT_MODULE_PATH);
+            if (empty($moduleName))
+            {
+                $this->_defaultModule = self::DEFAULT_MODULE;
+            }
+            else
+            {
+                try
+                {
+                    $helper = Mage::helper($moduleName);
+                    $this->_defaultModule = $moduleName;
+                }
+                catch (Exception $e)
+                {
+                    $this->_defaultModule = self::DEFAULT_MODULE;
+                }
+            }
+        }
+        return $this->_defaultModule;
+    }
 }

--- a/app/code/local/MB/Translate/Model/Template/Filter.php
+++ b/app/code/local/MB/Translate/Model/Template/Filter.php
@@ -2,50 +2,12 @@
 
 class MB_Translate_Model_Template_Filter extends Mage_Widget_Model_Template_Filter
 {
-    const XML_DEFAULT_MODULE_PATH = 'cms/translate/default_module';
-    const DEFAULT_MODULE          = 'page';
-    protected $_defaultModule     = null;
     public function translateDirective($construction)
     {
         $params = $this->_getIncludeParameters($construction[2]);
-        $text = $params['text'];
-        $module = (!empty($params['module'])) ? $this->_getTranslateModuleName($params['module']) : $this->_getDefaultModule();
-        return Mage::helper($module)->__($text);
-    }
-    protected function _getTranslateModuleName($module)
-    {
-        try
-        {
-            $helper = Mage::helper($module);
-            return $module;
-        }
-        catch (Exception $e)
-        {
-            return $this->_getDefaultModule();
-        }
-    }
-    protected function _getDefaultModule()
-    {
-        if (is_null($this->_defaultModule))
-        {
-            $moduleName = Mage::getStoreConfig(self::XML_DEFAULT_MODULE_PATH);
-            if (empty($moduleName))
-            {
-                $this->_defaultModule = self::DEFAULT_MODULE;
-            }
-            else
-            {
-                try
-                {
-                    $helper = Mage::helper($moduleName);
-                    $this->_defaultModule = $moduleName;
-                }
-                catch (Exception $e)
-                {
-                    $this->_defaultModule = self::DEFAULT_MODULE;
-                }
-            }
-        }
-        return $this->_defaultModule;
+        return Mage::helper('mb_translate')
+            ->getTranslateModule(isset($params['module']) ? $params['module'] : null)
+            ->__($params['text'])
+        ;
     }
 }

--- a/app/code/local/MB/Translate/etc/config.xml
+++ b/app/code/local/MB/Translate/etc/config.xml
@@ -30,6 +30,15 @@
             </page>
         </blocks>
     </global>
+    <frontend>
+        <layout>
+            <updates>
+                <mb_translate>
+                    <file>mb_translate.xml</file>
+                </mb_translate>
+            </updates>
+        </layout>
+    </frontend>
     <adminhtml>
         <translate>
             <modules>

--- a/app/code/local/MB/Translate/etc/config.xml
+++ b/app/code/local/MB/Translate/etc/config.xml
@@ -18,6 +18,17 @@
                 <class>MB_Translate_Helper</class>
             </mb_translate>
         </helpers>
+        <blocks>
+            <mb_translate>
+                <class>MB_Translate_Block</class>
+            </mb_translate>
+            <page>
+                <rewrite>
+                    <html_breadcrumbs>MB_Translate_Block_Page_Html_Breadcrumbs</html_breadcrumbs>
+                    <html_head>MB_Translate_Block_Page_Html_Head</html_head>
+                </rewrite>
+            </page>
+        </blocks>
     </global>
     <adminhtml>
         <translate>

--- a/app/design/frontend/base/default/layout/mb_translate.xml
+++ b/app/design/frontend/base/default/layout/mb_translate.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" ?>
+<layout version="0.1.0">
+    <default>
+        <!-- Enable translation in head on all pages -->
+        <reference name="head">
+            <action method="setTranslate">true</action>
+        </reference>
+    </default>
+    <print>
+        <!-- Enable translation in head on all pages -->
+        <reference name="head">
+            <action method="setTranslate">true</action>
+        </reference>
+    </print>
+    <!-- Replace header block -->
+    <cms_page translate="label">
+        <reference name="content">
+            <block type="mb_translate/core_template" name="page_content_heading" template="cms/content_heading.phtml"/>
+        </reference>
+    </cms_page>
+</layout>

--- a/modman
+++ b/modman
@@ -1,3 +1,4 @@
-app/code/local/MB/Translate         app/code/local/MB/Translate
-app/etc/modules/MB_Translate.xml    app/etc/modules/MB_Translate.xml
-app/locale/en_US/*.csv              app/locale/en_US/
+app/code/local/MB/Translate                               app/code/local/MB/Translate
+app/etc/modules/MB_Translate.xml                          app/etc/modules/MB_Translate.xml
+app/locale/en_US/*.csv                                    app/locale/en_US/
+app/design/frontend/base/default/layout/mb_translate.xml  app/design/frontend/base/default/layout/mb_translate.xml


### PR DESCRIPTION
This PR implements translation of title, header and breadcrumbs for pages.

I moved the module getter into Helper/Data in order to reuse the code for all classes in the extension.

Also I changed the filetype to UNIX to DOS for some of the files. It was mixed.
- [X] Translate title
- [X] Translate breadcrumb
- [X] Translate page header
- [ ] Specify module in those locations

This PR was started from #8 
